### PR TITLE
🐛 Arreglar lugar duplicado al seleccionar en mapa

### DIFF
--- a/src/componentes/MapaElemento.vue
+++ b/src/componentes/MapaElemento.vue
@@ -265,7 +265,7 @@ function eventoClic(seccion, contenedor, evento) {
           :key="`seccion-${seccion.codigo}`"
           class="lugar"
           :class="
-            cerebroGlobales.lugarSeleccionado && seccion.nombre === cerebroGlobales.lugarSeleccionado.nombre
+            cerebroGlobales.lugarSeleccionado && seccion.codigo === cerebroGlobales.lugarSeleccionado.codigo
               ? 'activo'
               : ''
           "


### PR DESCRIPTION
Al seleccionar un municipio en el mapa, arreglar el bug que seleccionaba  todos los lugares con el mismo nombre.